### PR TITLE
Add game models and Azure Blob storage

### DIFF
--- a/src/Web/Features/Game/AzureBlobBattleStorage.cs
+++ b/src/Web/Features/Game/AzureBlobBattleStorage.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Azure.Storage.Blobs;
+
+
+namespace ProjectGeoShot.Web.Features.Game;
+
+public class AzureBlobBattleStorage : IBattleStorage
+{
+    private readonly BlobContainerClient _container;
+
+    public AzureBlobBattleStorage(BlobServiceClient client, string containerName)
+    {
+        _container = client.GetBlobContainerClient(containerName);
+    }
+
+    public async Task SaveAsync(Battle battle, CancellationToken ct = default)
+    {
+        await _container.CreateIfNotExistsAsync(cancellationToken: ct);
+        var blob = _container.GetBlobClient(GetFileName(battle.Id));
+        using var stream = new MemoryStream();
+        await JsonSerializer.SerializeAsync(stream, battle, cancellationToken: ct);
+        stream.Position = 0;
+        await blob.UploadAsync(stream, overwrite: true, cancellationToken: ct);
+    }
+
+    public async Task<Battle?> LoadAsync(Guid battleId, CancellationToken ct = default)
+    {
+        var blob = _container.GetBlobClient(GetFileName(battleId));
+        if (!await blob.ExistsAsync(ct))
+            return null;
+
+        var response = await blob.DownloadAsync(cancellationToken: ct);
+        return await JsonSerializer.DeserializeAsync<Battle>(response.Value.Content, cancellationToken: ct);
+    }
+
+    private static string GetFileName(Guid id) => $"{id}.json";
+}

--- a/src/Web/Features/Game/Battle.cs
+++ b/src/Web/Features/Game/Battle.cs
@@ -1,0 +1,11 @@
+namespace ProjectGeoShot.Web.Features.Game;
+
+public class Battle
+{
+    public Guid Id { get; init; } = GuidV7.NewGuid();
+    public string Name { get; set; } = string.Empty;
+    public List<Player> Players { get; } = new();
+    public List<Shot> Shots { get; } = new();
+
+    public bool IsFull => Players.Count >= 16;
+}

--- a/src/Web/Features/Game/GuidV7.cs
+++ b/src/Web/Features/Game/GuidV7.cs
@@ -1,0 +1,23 @@
+using System.Security.Cryptography;
+
+namespace ProjectGeoShot.Web.Features.Game;
+
+public static class GuidV7
+{
+    public static Guid NewGuid()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        bytes[0] = (byte)(timestamp >> 40);
+        bytes[1] = (byte)(timestamp >> 32);
+        bytes[2] = (byte)(timestamp >> 24);
+        bytes[3] = (byte)(timestamp >> 16);
+        bytes[4] = (byte)(timestamp >> 8);
+        bytes[5] = (byte)timestamp;
+        bytes[6] = (byte)(0x70 | ((timestamp >> 56) & 0x0F));
+        RandomNumberGenerator.Fill(bytes.Slice(7));
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80); // RFC 4122 variant
+        return new Guid(bytes);
+    }
+}

--- a/src/Web/Features/Game/IBattleStorage.cs
+++ b/src/Web/Features/Game/IBattleStorage.cs
@@ -1,0 +1,7 @@
+namespace ProjectGeoShot.Web.Features.Game;
+
+public interface IBattleStorage
+{
+    Task SaveAsync(Battle battle, CancellationToken ct = default);
+    Task<Battle?> LoadAsync(Guid battleId, CancellationToken ct = default);
+}

--- a/src/Web/Features/Game/Player.cs
+++ b/src/Web/Features/Game/Player.cs
@@ -1,0 +1,7 @@
+namespace ProjectGeoShot.Web.Features.Game;
+
+public class Player
+{
+    public Guid Id { get; init; } = GuidV7.NewGuid();
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Web/Features/Game/Shot.cs
+++ b/src/Web/Features/Game/Shot.cs
@@ -1,0 +1,11 @@
+namespace ProjectGeoShot.Web.Features.Game;
+
+public class Shot
+{
+    public Guid Id { get; init; } = GuidV7.NewGuid();
+    public Guid PlayerId { get; init; }
+    public double Angle { get; set; }
+    public double Power { get; set; }
+    public WeatherSnapshot Weather { get; set; } = new(new(0,0), new(0,0));
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
+}

--- a/src/Web/Features/Game/WeatherSnapshot.cs
+++ b/src/Web/Features/Game/WeatherSnapshot.cs
@@ -1,0 +1,5 @@
+namespace ProjectGeoShot.Web.Features.Game;
+
+public record WindInfo(double Speed, double Deg);
+
+public record WeatherSnapshot(WindInfo Surface, WindInfo At500m);

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -1,5 +1,7 @@
 
 using ProjectGeoShot.Web.Features.Weather;
+using ProjectGeoShot.Web.Features.Game;
+using Azure.Storage.Blobs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,6 +9,10 @@ builder.Services
     .AddMemoryCache()
     .AddSingleton<IWeatherService, WeatherService>()
     .AddRazorPages();
+
+var connection = builder.Configuration["AzureBlobConnection"] ?? "UseDevelopmentStorage=true";
+builder.Services.AddSingleton<IBattleStorage>(sp =>
+    new AzureBlobBattleStorage(new BlobServiceClient(connection), "battles"));
 
 var app = builder.Build();
 

--- a/src/Web/ProjectGeoShot.Web.csproj
+++ b/src/Web/ProjectGeoShot.Web.csproj
@@ -6,5 +6,10 @@
 		<ImplicitUsings>true</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<CompressionEnabled>false</CompressionEnabled>
-	</PropertyGroup>
+</PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- model player, shot, battle, and weather data
- create `GuidV7` generator for sortable ids
- implement Azure Blob battle storage
- wire up storage service in Program
- reference Azure.Storage.Blobs NuGet package

## Testing
- `dotnet build --no-restore` *(fails: command not found)*